### PR TITLE
Add versioning for react-bootstrap and bootswatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Or, we can install a library from `npm` that will help.
 [Bootstrap](http://getbootstrap.com/) is popular UI toolkit for HTML and CSS. Let's install it, alongside `react-bootstrap` which provides the React components for it:
 
 ```sh
-npm install --save bootstrap react-bootstrap
+npm install --save bootstrap@3 react-bootstrap@0.30.8
 ```
 
 In the top of the app file, import the css from the bootstrap module:
@@ -274,6 +274,7 @@ Next, import the components we want to use from `react-bootstrap`. You can find 
 ```js
 import { Navbar, NavItem, Nav, Grid, Row, Col } from "react-bootstrap";
 ```
+**Side note** In later versions of react-bootstrap the *Grid* is renamed as *'Container'*. Also, in later versions, the *Navbar.Header* isn't available in [the Navbar API](https://react-bootstrap.netlify.com/components/navbar/#navbar-api).
 
 Now, replace the App component's render function to use the bootstrap components:
 
@@ -316,7 +317,7 @@ Now, replace the App component's render function to use the bootstrap components
 Now our app is starting to look more polished, but it would be nice to have a custom theme. We can install `bootswatch` to do that.
 
 ```sh
-npm install --save bootswatch
+npm install --save bootswatch@3
 ```
 
 [Browse the bootswatch website](http://bootswatch.com/) to find a theme, and install it by replacing the import of bootstrap css with the following. In this case we are using the 'journal' theme.


### PR DESCRIPTION
Added versions for `react-bootstrap` and `bootswatch`. Proofs:

- React-bootstrap on latest version: 
   - **Navbar.Header issue** [stackoverflow - react-js-navbar-header-element-type-is-invalid](https://stackoverflow.com/questions/55060067/react-js-navbar-header-element-type-is-invalid)
   - **Grid re-name** [Grid component rename in later version to Container](https://react-bootstrap.netlify.com/migrating/) via [this](https://teamtreehouse.com/community/failed-to-compile-2).

Btw, thank you for the clear explanations. Thanks to you I am able to create my very first (even if real bare bones) React app!
The app: http://toomuchof.me :D